### PR TITLE
Sort Key & Order Conf, Updated Docs

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,11 +5,8 @@ Adds Solr search to Spree using [Sunspot](https://github.com/sunspot/sunspot). T
 
 This is compatible with Spree 1.2. I haven't tested it below that.
 
-
-Install
-=======
-
-I make the assumption that you have a functioning Spree store and are just extending the search capabilities with Sunspot/Solr
+Installation
+============
 
 Add spree_sunspot_search to your Gemfile and run bundler.
 
@@ -30,27 +27,50 @@ Copy the initializer and add `solr_sort_by` to `all.js`
 
 `rails g spree_sunspot_search:install`
 
-Running
-=======
+Running & Indexing
+==================
 
 Start up Solr (bundled with Sunspot's install)
 
-`rake sunspot:solr:run`
+`bundle exec rake sunspot:solr:run`
 
 Build the index for the first time
 
-`rake sunspot:reindex`
+`bundle exec rake sunspot:reindex`
 
-Customise the Facets Shown
---------------------------
+Stop the solr process:
 
-Edit the initializer and specify you Product Properties, Product Options, and Price Ranges as an array.
+`bundle exec rake sunspot:solr:stop`
+
+Customization
+=============
+
+Production Server
+-----------------
+To configure development / production solr server edit `$RAILS_ROOT/config/solr.yml`.
+Read the [sunspot documentation](https://github.com/sunspot/sunspot/wiki/Configuring-solr-for-use-with-sunspot-in-development%2C-testing%2C-and-production)
+and [this great post](http://stackoverflow.com/questions/4937314/setup-sunspot-solr-with-rails-in-production-environment) for more information about production configuration.
+
+Below is a sample config for production that works well for a site with relatively low search traffic and capistrano based deployment:
+
+
+    production:
+      solr:
+        hostname: 127.0.0.1
+        bind_address: 127.0.0.1
+        port: 8983
+        log_level: WARNING
+        max_memory: 100M
+        data_path: /data/spree/shared/solr/data
+        pid_dir: /data/spree/shared/solr/pids
+        solr_home: /data/spree/shared/solr
+      auto_commit_after_request: false
+
+Facets
+------
+
+Edit the [initializer](https://github.com/iloveitaly/spree_sunspot_search/blob/master/lib/generators/templates/spree_sunspot_search.rb) and specify you Product Properties, Product Options, and Price Ranges as an array.
 The initializer should provide enough examples to get you started.
-
-Testing
-=======
-
-TODO
 
 TODOs
 =====
@@ -59,6 +79,7 @@ TODOs
 * Sorting by facet criteria and Solr analytics (Best result, Popular, etc.)
 * Open the Sunspot DSL to utilise all the additional data and analytics available through Solr
 * Get the Taxon browsing (e.g. Categories) to utilise the Solr data for speed boosts
+* Testing via https://github.com/justinko/sunspot-rails-tester + rspec
 
 Authors
 =======

--- a/app/models/product_decorator.rb
+++ b/app/models/product_decorator.rb
@@ -2,7 +2,7 @@ Spree::Product.class_eval do
   searchable do
     boolean :is_active, :using => :is_active?
 
-    conf = Spree::Search::Sunspot.configuration
+    conf = Spree::Search.configuration
 
     conf.fields.each do |field|
       if field.class == Hash
@@ -61,7 +61,7 @@ Spree::Product.class_eval do
 
   def price_range
     max = 0
-    Spree::Search::Sunspot.configuration.price_ranges.each do |range, name|
+    Spree::Search.configuration.price_ranges.each do |range, name|
       return name if range.include?(price)
       max = range.max if range.max > max
     end
@@ -83,3 +83,4 @@ Spree::Product.class_eval do
     Spree::OptionValue.find_by_sql(sql)
   end
 end
+

--- a/app/models/spree/sunspot_configuration.rb
+++ b/app/models/spree/sunspot_configuration.rb
@@ -1,5 +1,0 @@
-module Spree
-  class SunspotConfiguration < Preferences::Configuration
-    preference :facet_display_limit, :integer, :default => -1
-  end
-end

--- a/app/overrides/add_search_pagination.rb
+++ b/app/overrides/add_search_pagination.rb
@@ -1,5 +1,5 @@
-Deface::Override.new(:virtual_path => "spree/shared/_products", 
-                      :name => "add_sunspot_search_pagination", 
+Deface::Override.new(:virtual_path => "spree/shared/_products",
+                      :name => "add_sunspot_search_pagination",
                       :replace => "code[erb-silent]:contains('if paginated_products.respond_to')",
                       :closing_selector => "code[erb-silent]:contains('end')",
                       :text => "<%= paginate @searcher.sunspot.hits %>")

--- a/app/overrides/add_search_suggestion.rb
+++ b/app/overrides/add_search_suggestion.rb
@@ -1,5 +1,6 @@
 # unfortunately it doesn't look like sunspot has spell check support yet
 #   https://github.com/sunspot/sunspot/pull/43
+#   https://github.com/climbingrose/sunspot/commit/7c92c536d6eb500b10dcc7d6fa33870429bdbc82
 
 # Deface::Override.new(:virtual_path => "spree/products/index",
 #                       :name => "show_search_partials_suggestion",

--- a/app/views/spree/products/_facets.html.erb
+++ b/app/views/spree/products/_facets.html.erb
@@ -1,6 +1,7 @@
 <%
-facets_arr = Spree::Search.configuration.display_facets
-limit = Spree::SunspotSearch::Config[:facet_display_limit]
+conf = Spree::Search.configuration
+facets_arr = conf.display_facets
+limit = conf.facet_display_limit
 
 if @taxon
     display_list = @taxon.leaf? ? [@taxon.id] : @taxon.children.map(&:id)

--- a/app/views/spree/products/_facets.html.erb
+++ b/app/views/spree/products/_facets.html.erb
@@ -1,5 +1,5 @@
 <%
-facets_arr = Spree::Search::SpreeSunspot.configuration.display_facets
+facets_arr = Spree::Search.configuration.display_facets
 limit = Spree::SunspotSearch::Config[:facet_display_limit]
 
 if @taxon
@@ -40,3 +40,4 @@ if taxon_rows.length > 1 %>
     <% end %>
 </ul>
 <% end %>
+

--- a/app/views/spree/products/_sort_bar.html.erb
+++ b/app/views/spree/products/_sort_bar.html.erb
@@ -5,7 +5,6 @@ if not params.keys.detect { |k| k != 'controller' and k != 'action' }.nil? and p
 	options = Spree::Search.configuration.sort_fields.map do |key, value|
 		# value is sort direction
 		value = [value] if !value.is_a? Array
-		Rails.logger.info "Array Key sort.#{key}_#{value}"
 		value.map { |sort| [t("sort.#{key}_#{sort}"), url_for(request.params.merge({:sort => key, :order => sort}))] }
 	end
 

--- a/app/views/spree/products/_sort_bar.html.erb
+++ b/app/views/spree/products/_sort_bar.html.erb
@@ -2,7 +2,7 @@
 if not params.keys.detect { |k| k != 'controller' and k != 'action' }.nil? and params[:controller] != 'spree/taxons'
 	# hate to throw this logic here (messy)
 	# I think it would be worse to create a one-time-use helper method
-	options = Spree::Search::SpreeSunspot.configuration.sort_fields.map do |key, value|
+	options = Spree::Search.configuration.sort_fields.map do |key, value|
 		# value is sort direction
 		value = [value] if !value.is_a? Array
 		Rails.logger.info "Array Key sort.#{key}_#{value}"
@@ -16,3 +16,4 @@ if not params.keys.detect { |k| k != 'controller' and k != 'action' }.nil? and p
 %>
 <div id="product-list-sort"><%= t(:sort_by) %> <%= select_tag("product_sort_by", options) %></div>
 <% end %>
+

--- a/lib/generators/templates/spree_sunspot_search.rb
+++ b/lib/generators/templates/spree_sunspot_search.rb
@@ -1,7 +1,7 @@
 # Take a look at the Spree::Search::SpreeSunspot::Configuration class for details
 # it is important that all 'block fields' return an empty string and not nil
 
-# Spree::Search::SpreeSunspot.configure do |conf|
+# Spree::Search.configure do |conf|
 #   conf.price_ranges = []
 #   conf.option_facets = []
 #   conf.property_facets = []

--- a/lib/spree/search/configuration.rb
+++ b/lib/spree/search/configuration.rb
@@ -7,7 +7,10 @@ module Spree
                     :other_facets,
                     :show_facets,
                     :fields,
-                    :sort_fields
+                    :sort_fields,
+                    :default_sort_key,
+                    :default_sort_order,
+                    :facet_display_limit
 
       def initialize
         # Price ranges to be used for faceting
@@ -37,10 +40,15 @@ module Spree
         # in the suggestions partial
         self.show_facets = []
 
+        self.facet_display_limit = 1
+
         self.sort_fields = {
           :score => :desc,
           :price => [:asc, :desc],
         }
+
+        self.default_sort_key = :score
+        self.default_sort_order = :desc
       end
 
       def display_facets

--- a/lib/spree/search/configuration.rb
+++ b/lib/spree/search/configuration.rb
@@ -35,7 +35,7 @@ module Spree
 
         # facets that have already been created and should be displayed
         # in the suggestions partial
-        self.show_facets = [:taxon_name]
+        self.show_facets = []
 
         self.sort_fields = {
           :score => :desc,
@@ -62,3 +62,4 @@ end
 
 # TODO move this to a more appropriate / intention revealing location
 Spree::Search.configuration {}
+

--- a/lib/spree/search/engine.rb
+++ b/lib/spree/search/engine.rb
@@ -15,11 +15,9 @@ module Spree
           Rails.configuration.cache_classes ? require(c) : load(c)
         end
 
-        # Load application's view overrides
-        Dir.glob(File.join(File.dirname(__FILE__), "../../../app/overrides/**/*.rb")) do |c|
-          Rails.configuration.cache_classes ? require(c) : load(c)
+        if Rails.env.development?
+          Spree::Config.searcher_class = Spree::Search::SpreeSunspot::Search
         end
-
       end
       config.to_prepare &method(:activate).to_proc
     end

--- a/lib/spree/search/engine.rb
+++ b/lib/spree/search/engine.rb
@@ -7,7 +7,6 @@ module Spree
 
       initializer "spree.sunspot_search.preferences", :after => "spree.environment" do |app|
         Spree::Config.searcher_class = Spree::Search::Sunspot
-        Spree::SunspotSearch::Config = Spree::SunspotConfiguration.new
       end
 
       def self.activate
@@ -16,7 +15,7 @@ module Spree
         end
 
         if Rails.env.development?
-          Spree::Config.searcher_class = Spree::Search::SpreeSunspot::Search
+          Spree::Config.searcher_class = Spree::Search::Sunspot
         end
       end
       config.to_prepare &method(:activate).to_proc

--- a/lib/spree/search/engine.rb
+++ b/lib/spree/search/engine.rb
@@ -7,16 +7,22 @@ module Spree
 
       initializer "spree.sunspot_search.preferences", :after => "spree.environment" do |app|
         Spree::Config.searcher_class = Spree::Search::Sunspot
-        Spree::Search::Sunspot::Config = Spree::Search::Sunspot::Configuration.new
+        Spree::SunspotSearch::Config = Spree::SunspotConfiguration.new
       end
 
       def self.activate
-        Dir.glob(File.join(File.dirname(__FILE__), "../app/**/*_decorator*.rb")) do |c|
+        Dir.glob(File.join(File.dirname(__FILE__), "../../../app/**/*_decorator*.rb")) do |c|
           Rails.configuration.cache_classes ? require(c) : load(c)
         end
-      end
 
+        # Load application's view overrides
+        Dir.glob(File.join(File.dirname(__FILE__), "../../../app/overrides/**/*.rb")) do |c|
+          Rails.configuration.cache_classes ? require(c) : load(c)
+        end
+
+      end
       config.to_prepare &method(:activate).to_proc
     end
   end
 end
+

--- a/lib/spree/search/sunspot.rb
+++ b/lib/spree/search/sunspot.rb
@@ -48,13 +48,19 @@ module Spree
         # the faceting partial is kind of 'dumb' about the params object: doesn't clean it out and just
         # dumps all the params into the query string
 
+        conf = Spree::Search.configuration
+
         @properties[:query] = params[:keywords]
         @properties[:price] = params[:price]
 
-        @properties[:sort] = params[:sort] || :score
-        @properties[:order] = params[:order] || :desc
+        @properties[:sort] = params[:sort] || conf.default_sort_key
+        @properties[:order] = params[:order] || conf.default_sort_order
 
-        Spree::Search.configuration.display_facets.each do |name|
+        # ensure that :sort and :order are legit
+        @properties[:sort] = :score unless conf.sort_fields.keys.include? @properties[:sort]
+        @properties[:order] = :desc unless [:desc, :asc].include? @properties[:sort]
+
+        conf.display_facets.each do |name|
           @properties[name] ||= params["#{name}_facet"]
         end
       end

--- a/lib/spree/search/sunspot.rb
+++ b/lib/spree/search/sunspot.rb
@@ -63,3 +63,4 @@ module Spree
 
   end
 end
+

--- a/lib/spree_sunspot_search.rb
+++ b/lib/spree_sunspot_search.rb
@@ -6,8 +6,11 @@ require 'sunspot_rails'
 module Spree
   module Search
   end
+  module SunspotSearch
+  end
 end
 
 require 'spree/search/engine'
 require 'spree/search/sunspot'
 require 'spree/search/configuration'
+

--- a/spree_sunspot_search.gemspec
+++ b/spree_sunspot_search.gemspec
@@ -15,7 +15,7 @@ Gem::Specification.new do |s|
   s.require_path = 'lib'
   s.requirements << 'none'
 
-  s.add_dependency('spree_core', '~> 1.2.0')
+  s.add_dependency('spree_core', '~> 1.1')
   s.add_dependency('sunspot_rails')
   s.add_dependency('progress_bar')
 


### PR DESCRIPTION
- Added configuration options for sort key and sort order
- Ensures that sort key & sort order is valid before passing to sunspot
- Removed `Spree::SunspotConfiguration`; moved to `Spree::Search::Configuration`
- Works fine on spree 1.x, eliminated 1.2 requirement
