### PR TITLE
Fix configuration initializer

### DIFF
--- a/app/models/product_decorator.rb
+++ b/app/models/product_decorator.rb
@@ -2,7 +2,7 @@ Spree::Product.class_eval do
   searchable do
     boolean :is_active, :using => :is_active?
 
-    conf = Spree::Search::Sunspot.configuration
+    conf = Spree::Search.configuration
 
     conf.fields.each do |field|
       if field.class == Hash
@@ -61,7 +61,7 @@ Spree::Product.class_eval do
 
   def price_range
     max = 0
-    Spree::Search::Sunspot.configuration.price_ranges.each do |range, name|
+    Spree::Search.configuration.price_ranges.each do |range, name|
       return name if range.include?(price)
       max = range.max if range.max > max
     end
@@ -83,3 +83,4 @@ Spree::Product.class_eval do
     Spree::OptionValue.find_by_sql(sql)
   end
 end
+

--- a/app/views/spree/products/_facets.html.erb
+++ b/app/views/spree/products/_facets.html.erb
@@ -1,5 +1,5 @@
 <%
-facets_arr = Spree::Search::SpreeSunspot.configuration.display_facets
+facets_arr = Spree::Search.configuration.display_facets
 limit = Spree::SunspotSearch::Config[:facet_display_limit]
 
 if @taxon
@@ -40,3 +40,4 @@ if taxon_rows.length > 1 %>
     <% end %>
 </ul>
 <% end %>
+

--- a/app/views/spree/products/_sort_bar.html.erb
+++ b/app/views/spree/products/_sort_bar.html.erb
@@ -2,7 +2,7 @@
 if not params.keys.detect { |k| k != 'controller' and k != 'action' }.nil? and params[:controller] != 'spree/taxons'
 	# hate to throw this logic here (messy)
 	# I think it would be worse to create a one-time-use helper method
-	options = Spree::Search::SpreeSunspot.configuration.sort_fields.map do |key, value|
+	options = Spree::Search.configuration.sort_fields.map do |key, value|
 		# value is sort direction
 		value = [value] if !value.is_a? Array
 		Rails.logger.info "Array Key sort.#{key}_#{value}"
@@ -16,3 +16,4 @@ if not params.keys.detect { |k| k != 'controller' and k != 'action' }.nil? and p
 %>
 <div id="product-list-sort"><%= t(:sort_by) %> <%= select_tag("product_sort_by", options) %></div>
 <% end %>
+

--- a/lib/spree/search/configuration.rb
+++ b/lib/spree/search/configuration.rb
@@ -61,5 +61,5 @@ module Spree
 end
 
 # TODO move this to a more appropriate / intention revealing location
-Spree::Search.configuration {}
+Spree::Search.configure {}
 

--- a/lib/spree/search/configuration.rb
+++ b/lib/spree/search/configuration.rb
@@ -35,7 +35,7 @@ module Spree
 
         # facets that have already been created and should be displayed
         # in the suggestions partial
-        self.show_facets = [:taxon_name]
+        self.show_facets = []
 
         self.sort_fields = {
           :score => :desc,
@@ -62,3 +62,4 @@ end
 
 # TODO move this to a more appropriate / intention revealing location
 Spree::Search.configuration {}
+

--- a/lib/spree/search/engine.rb
+++ b/lib/spree/search/engine.rb
@@ -7,16 +7,22 @@ module Spree
 
       initializer "spree.sunspot_search.preferences", :after => "spree.environment" do |app|
         Spree::Config.searcher_class = Spree::Search::Sunspot
-        Spree::Search::Sunspot::Config = Spree::Search::Sunspot::Configuration.new
+        Spree::SunspotSearch::Config = Spree::SunspotConfiguration.new
       end
 
       def self.activate
-        Dir.glob(File.join(File.dirname(__FILE__), "../app/**/*_decorator*.rb")) do |c|
+        Dir.glob(File.join(File.dirname(__FILE__), "../../../app/**/*_decorator*.rb")) do |c|
           Rails.configuration.cache_classes ? require(c) : load(c)
         end
-      end
 
+        # Load application's view overrides
+        Dir.glob(File.join(File.dirname(__FILE__), "../../../app/overrides/**/*.rb")) do |c|
+          Rails.configuration.cache_classes ? require(c) : load(c)
+        end
+
+      end
       config.to_prepare &method(:activate).to_proc
     end
   end
 end
+

--- a/lib/spree/search/sunspot.rb
+++ b/lib/spree/search/sunspot.rb
@@ -63,3 +63,4 @@ module Spree
 
   end
 end
+

--- a/lib/spree_sunspot_search.rb
+++ b/lib/spree_sunspot_search.rb
@@ -6,8 +6,11 @@ require 'sunspot_rails'
 module Spree
   module Search
   end
+  module SunspotSearch
+  end
 end
 
 require 'spree/search/engine'
 require 'spree/search/sunspot'
 require 'spree/search/configuration'
+


### PR DESCRIPTION
Seems that Spree::Search.configuration was a typo, huh? It caused `nil` error at [this line](https://github.com/jbrien/spree_sunspot_search/blob/master/app/models/product_decorator.rb#L7) with my app.
